### PR TITLE
add Legion Go hardware patches by appsforartists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 !0003-Default-to-maximum-amount-of-ASLR-bits.patch
 !0005-fix-doc-build.patch
 
+!legion-go-controllers.patch
+!legion-go-display-quirk.patch
+
 !tkg.patch
 !fsync.patch
 !amdgpu-si-cik-default.patch

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -32,6 +32,9 @@ source=(
   # 0003-Default-to-maximum-amount-of-ASLR-bits.patch
   # 0005-fix-doc-build.patch
 
+  legion-go-display-quirk.patch
+  legion-go-controllers.patch
+
   # linux-fsync patches
   tkg.patch
   fsync.patch

--- a/legion-go-controllers.patch
+++ b/legion-go-controllers.patch
@@ -1,0 +1,57 @@
+From e3731167d3caff0857e5700c9129e4d8a386aa6a Mon Sep 17 00:00:00 2001
+From: Brenton Simpson <appsforartists@users.noreply.github.com>
+Date: Tue, 14 Nov 2023 22:18:28 -0800
+Subject: [PATCH] Input: xpad - add Lenovo Legion Go controllers
+
+The Lenovo Legion Go is a handheld gaming system, similar to a Steam Deck.
+It has a gamepad (including rear paddles), 3 gyroscopes, a trackpad,
+volume buttons, a power button, and 2 LED ring lights.
+
+The Legion Go firmware presents these controls as a USB hub with various
+devices attached.  In its default state, the gamepad is presented as an
+Xbox controller connected to this hub.  (By holding a combination of
+buttons, it can be changed to use the older DirectInput API.)
+
+This patch teaches the existing Xbox controller module `xpad` to bind to
+the controller in the Legion Go, which enables support for the:
+
+- directional pad,
+- analog sticks (including clicks),
+- X, Y, A, B,
+- start and select (or menu and capture),
+- shoulder buttons, and
+- rumble.
+
+The trackpad, touchscreen, volume controls, and power button are already
+supported via existing kernel modules.  Two of the face buttons, the
+gyroscopes, rear paddles, and LEDs are not.
+
+After this patch lands, the Legion Go will be mostly functional in Linux,
+out-of-the-box.  The various components of the USB hub can be synthesized
+into a single logical controller (including the additional buttons) in
+userspace with [Handheld Daemon](https://github.com/hhd-dev/hhd), which
+makes the Go fully functional.
+---
+ drivers/input/joystick/xpad.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/input/joystick/xpad.c b/drivers/input/joystick/xpad.c
+index b1244d7df6cc9e..7c4b2a5cc1b54a 100644
+--- a/drivers/input/joystick/xpad.c
++++ b/drivers/input/joystick/xpad.c
+@@ -294,6 +294,7 @@ static const struct xpad_device {
+  { 0x1689, 0xfd00, "Razer Onza Tournament Edition", 0, XTYPE_XBOX360 },
+  { 0x1689, 0xfd01, "Razer Onza Classic Edition", 0, XTYPE_XBOX360 },
+  { 0x1689, 0xfe00, "Razer Sabertooth", 0, XTYPE_XBOX360 },
++ { 0x17ef, 0x6182, "Lenovo Legion Controller for Windows", 0, XTYPE_XBOX360 },
+  { 0x1949, 0x041a, "Amazon Game Controller", 0, XTYPE_XBOX360 },
+  { 0x1bad, 0x0002, "Harmonix Rock Band Guitar", 0, XTYPE_XBOX360 },
+  { 0x1bad, 0x0003, "Harmonix Rock Band Drumkit", MAP_DPAD_TO_BUTTONS, XTYPE_XBOX360 },
+@@ -491,6 +492,7 @@ static const struct usb_device_id xpad_table[] = {
+  XPAD_XBOX360_VENDOR(0x15e4),    /* Numark Xbox 360 controllers */
+  XPAD_XBOX360_VENDOR(0x162e),    /* Joytech Xbox 360 controllers */
+  XPAD_XBOX360_VENDOR(0x1689),    /* Razer Onza */
++ XPAD_XBOX360_VENDOR(0x17ef),    /* Lenovo */
+  XPAD_XBOX360_VENDOR(0x1949),    /* Amazon controllers */
+  XPAD_XBOX360_VENDOR(0x1bad),    /* Harmonix Rock Band guitar and drums */
+  XPAD_XBOX360_VENDOR(0x20d6),    /* PowerA controllers */

--- a/legion-go-display-quirk.patch
+++ b/legion-go-display-quirk.patch
@@ -1,0 +1,30 @@
+From c2a46e1540e9dc276c1aaf8398ae874956e3aa3f Mon Sep 17 00:00:00 2001
+From: Brenton Simpson <appsforartists@users.noreply.github.com>
+Date: Tue, 14 Nov 2023 12:46:19 -0800
+Subject: [PATCH] drm/panel-orientation-quirks: add Lenovo Legion Go
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Legion Go has a 2560x1600 portrait screen, with the native "up" facing the right controller (90° CW from the rest of the device).
+---
+ drivers/gpu/drm/drm_panel_orientation_quirks.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index d5c15292ae9378..3d92f66e550c38 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -336,6 +336,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		  DMI_EXACT_MATCH(DMI_PRODUCT_VERSION, "IdeaPad Duet 3 10IGL5"),
+ 		},
+ 		.driver_data = (void *)&lcd1200x1920_rightside_up,
++	}, {	/* Lenovo Legion Go 8APU1 */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "LENOVO"),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_VERSION, "Legion Go 8APU1"),
++		},
++		.driver_data = (void *)&lcd1600x2560_leftside_up,
+ 	}, {	/* Lenovo Yoga Book X90F / X90L */
+ 		.matches = {
+ 		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Intel Corporation"),


### PR DESCRIPTION
These were written for 6.6, so they should apply cleanly. 

I also have a version of [the controller patch rebased to Valve LTS](https://gist.github.com/appsforartists/1ba55423dd1962625f070fa8ac3deba7#file-legion-go-controllers-valve-patch) if that applies better.